### PR TITLE
add requirement for billing setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,9 @@ Additional parameters can specify the paths to files that will be included as co
 <br />
 
 ## Requirements
-Node 18 is required
+- Node 18
+- [API key from OpenAI](https://beta.openai.com/account/api-keys)
+- [Billing setup in OpenAI](https://platform.openai.com/account/billing/overview)
 
 <br />
 


### PR DESCRIPTION
Initially I was getting errors, and didn't realise that while I had an API key, I didn't have billing enabled in OpenAI. Thought this might help others.