### PR TITLE
Automatically detect and send files that are mentioned in the prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,33 @@
 # Promptr
 
-## TLDR 
-Promptr is a CLI tool that makes it easy to apply GPT's code change recommendations with a single command. With Promptr, you can quickly refactor code, implement classes to pass tests, and experiment with LLMs. No more copying code from the ChatGPT window into your editor. 
-
-<br />
-
-[This PR](https://github.com/ferrislucas/promptr/pull/38) has some good examples of what can be accomplished using Promptr. You can find links to the individual commits and the prompts that created them in the PR description.
-
+Promptr is a CLI tool that lets you use plain English to instruct GPT3 or GPT4 to make changes to your codebase. This is most effective with GPT4 because of its larger context window, but GPT3 is still useful for smaller scopes. 
 <br /><br />
 
-## Introduction
-Promptr automates the process of providing ChatGPT with source code and a prompt, and then applying ChatGPT's response to the filesystem. This allows you to apply plain English instructions to your codebase. This is most effective with GPT4 because of its larger context window, but GPT3 is still useful for smaller scopes. 
-<br />
+The PR's below are good examples of what can be accomplished using Promptr. You can find links to the individual commits and the prompts that created them in the PR descriptions.
+- https://github.com/ferrislucas/promptr/pull/38
+- https://github.com/ferrislucas/promptr/pull/41
+<br /><br />
 
-I've found this to be good workflow:
-- Commit any changes, so you have a clean working area
-- Author your prompt in a text file. Work with the prompt in your favorite editor - mold it into clear instructions almost as if it's a task for an inexperienced co-worker. 
-- Use promptr to send your prompt __and the relevant files__ to GPT. It's critical to send the relevant files with your request. Think about what files your inexperienced co-worker would need to know about in order to fulfill the request.
-- Complex requests can take a while (or timeout). When the response is ready, promptr applies the changes to your filesystem. Use your favorite git UI to inspect the results. 
+I've found this to be a good workflow:
+- Commit any changes, so you have a clean working area.
+- Author your prompt in a text file. The prompt should be specific clear instructions. 
+- Make sure your prompt contains the relative paths of any files that are relevant to your instructions. 
+- Use Promptr to execute your prompt. Provide the path to your prompt file using the `-p` option: 
+`promptr -p my_prompt.txt` 
+*If you have access to GPT4 then use the `-m gpt4` option to get the best results.*
+
+Complex requests can take a while. If a task is too complex then the request will timeout - try breaking the task down into smaller units of work when this happens. When the response is ready, promptr applies the changes to your filesystem. Use your favorite git UI to inspect the results. 
 
 <br /><br />
 
 
 ## Examples
 __Cleanup the code in a file__
+Promptr recognizes that the file `src/index.js` is referenced in the prompt, so the contents of `src/index.js` is automatically sent to the model along with the prompt.
 ```bash
-$ promptr -p "Cleanup the code in this file" index.js
+$ promptr -p "Cleanup the code in src/index.js"
 ```
-<br />
-
-__Cleanup the code in two files__
-<br />
-The following example uses GPT4 to cleanup the code in two files by passing the file paths as arguments:
-```bash
-$ promptr -m gpt4 -p "Cleanup the code in these files" app/index.js app.js 
-```
-<br />
+<br /><br />
 
 __Alphabetize the methods in all of the javascript files__ 
 <br />

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Sit back... Relaaxxxxxx... let Promptr carry you on a gentle cruise through a li
 - `-x` Optional boolean flag. Promptr attempts to parse the model's response and apply the resulting operations to the current directory tree whe using the "refactor" template. You only need to pass the `-x` flag if you've created your own template, and you want Promptr to parse the output of your template in the same way that the built in "refactor" template is parsed.
 - `-o, --output-path <outputPath>`: Optional string flag that specifies the path to the output file. If this flag is not set, the output will be printed to stdout.
 - `-v, --verbose`: Optional boolean flag that enables verbose output, providing more detailed information during execution.
+- `-dac, --disable-auto-context`: Prevents files referenced in the prompt from being automatically included in the context sent to the model.
 - `--version`: Display the version and exit
 
 Additional parameters can specify the paths to files that will be included as context in the prompt. The parameters should be separated by a space.

--- a/src/cliState.js
+++ b/src/cliState.js
@@ -68,8 +68,6 @@ Example call:
   }
 
   static disableAutoContext() {
-    console.log(`options: ${JSON.stringify(this.program.opts())}`)
-    console.log(`result: ${!!this.program.opts().disableAutoContext}`)
     return !!this.program.opts().disableAutoContext
   }
 

--- a/src/cliState.js
+++ b/src/cliState.js
@@ -7,13 +7,14 @@ export default class CliState {
   static init(_args, version) {
     this.program = new Command();
     this.program.option('-d, --dry-run', 'Dry run only: just display the prompt')
-    this.program.option('-i, --interactive', 'Interactive mode');
-    this.program.option('-x, --execute', 'Apply changes suggested by GPT to the local filesystem. The "refactor" template auotmatically applies the changes. You would only use this option if you create your own templates.');
-    this.program.option('-p, --prompt <prompt>', 'Prompt to use in non-interactive mode');
+    this.program.option('-i, --interactive', 'Interactive mode')
+    this.program.option('-x, --execute', 'Apply changes suggested by GPT to the local filesystem. The "refactor" template auotmatically applies the changes. You would only use this option if you create your own templates.')
+    this.program.option('-p, --prompt <prompt>', 'Prompt to use in non-interactive mode')
     this.program.option('-t, --template <template>', 'Teplate name, template path, or a url for a template file')
     this.program.option('-o, --output-path <outputPath>', 'Path to output file. If no path is specified, output will be printed to stdout.')
     this.program.option('-v, --verbose', 'Verbose output')
     this.program.option('-m, --model <model>', 'Specify the model: (gpt3|gpt4)', 'gpt3')
+    this.program.option('-dac, --disable-auto-context', 'Prevents files referenced in the prompt from being automatically included in the context sent to the model.');
     
     this.program.version(version, '--version', 'Display the current version')
     
@@ -64,6 +65,12 @@ Example call:
 
   static isInteractive() {
     return this.program.opts().interactive
+  }
+
+  static disableAutoContext() {
+    console.log(`options: ${JSON.stringify(this.program.opts())}`)
+    console.log(`result: ${!!this.program.opts().disableAutoContext}`)
+    return !!this.program.opts().disableAutoContext
   }
 
 }

--- a/src/services/AutoContext.js
+++ b/src/services/AutoContext.js
@@ -1,5 +1,5 @@
 export class AutoContext {
-  static call() {
+  static call(prompt) {
     return []
   }
 }

--- a/src/services/AutoContext.js
+++ b/src/services/AutoContext.js
@@ -1,5 +1,13 @@
 export default class AutoContext {
   static call(prompt) {
-    return []
+    const filePaths = [];
+    const regex = /(?:^|[\s"])(\/?[\w\.\-\/]+\.\w+)/g;
+    let match;
+
+    while ((match = regex.exec(prompt)) !== null) {
+      filePaths.push(match[1]);
+    }
+
+    return filePaths;
   }
 }

--- a/src/services/AutoContext.js
+++ b/src/services/AutoContext.js
@@ -1,4 +1,4 @@
-export class AutoContext {
+export default class AutoContext {
   static call(prompt) {
     return []
   }

--- a/src/services/AutoContext.js
+++ b/src/services/AutoContext.js
@@ -1,4 +1,10 @@
 export default class AutoContext {
+  /**
+   * Extracts file paths from the given prompt.
+   *
+   * @param {string} prompt - The input prompt containing file paths.
+   * @returns {string[]} An array of extracted file paths.
+   */
   static call(prompt) {
     const filePaths = [];
     const regex = /(?:^|[\s"])(\/?[\w\.\-\/]+\.\w+)/g;

--- a/src/services/AutoContext.js
+++ b/src/services/AutoContext.js
@@ -1,0 +1,5 @@
+export class AutoContext {
+  static call() {
+    return []
+  }
+}

--- a/src/services/fileService.js
+++ b/src/services/fileService.js
@@ -7,14 +7,14 @@ export class FileService {
 
   static async load(filePath) {
     const fileDoesNotExist = !await this.fileExists(filePath)
-    if (fileDoesNotExist) return("")
+    if (fileDoesNotExist) return null
     try {
       // Use the fs module to read the file
       const data = await fs.promises.readFile(filePath, "utf-8")
       return data
     } catch (err) {
       this.log(err)
-      return("")
+      return null
     }
   }
 

--- a/src/services/pluginService.js
+++ b/src/services/pluginService.js
@@ -7,6 +7,7 @@ import OpenAiGptService from './OpenAiGptService.js'
 import RefactorResultProcessor from './refactorResultProcessor.js'
 import TemplateLoader from './templateLoaderService.js'
 import PromptContext from './promptContext.js'
+import { AutoContext } from './AutoContext.js'
 import { extractOperationsFromOutput } from './extractOperationsFromOutput.js'
 
 export default class PluginService {
@@ -21,7 +22,7 @@ export default class PluginService {
       return 1
     }
     if (CliState.getModel() != "execute") {
-      let context = await PromptContext.call(CliState.args)
+      let context = await PromptContext.call(CliState.args.concat(AutoContext.call()))
       const __filename = fileURLToPath(import.meta.url)
 
       let templatePath = "refactor"

--- a/src/services/pluginService.js
+++ b/src/services/pluginService.js
@@ -22,7 +22,9 @@ export default class PluginService {
       return 1
     }
     if (CliState.getModel() != "execute") {
-      let context = await PromptContext.call(CliState.args.concat(AutoContext.call(userInput)))
+      let args = CliState.args      
+      if (!CliState.disableAutoContext()) args = args.concat(AutoContext.call(userInput))      
+      let context = await PromptContext.call(args)
       const __filename = fileURLToPath(import.meta.url)
 
       let templatePath = "refactor"

--- a/src/services/pluginService.js
+++ b/src/services/pluginService.js
@@ -22,7 +22,7 @@ export default class PluginService {
       return 1
     }
     if (CliState.getModel() != "execute") {
-      let context = await PromptContext.call(CliState.args.concat(AutoContext.call()))
+      let context = await PromptContext.call(CliState.args.concat(AutoContext.call(userInput)))
       const __filename = fileURLToPath(import.meta.url)
 
       let templatePath = "refactor"

--- a/src/services/pluginService.js
+++ b/src/services/pluginService.js
@@ -1,5 +1,4 @@
 import { fileURLToPath } from 'url'
-import { dirname } from 'path'
 import { encode } from "gpt-3-encoder"
 import { FileService } from './fileService.js'
 import CliState from '../cliState.js'
@@ -7,7 +6,7 @@ import OpenAiGptService from './OpenAiGptService.js'
 import RefactorResultProcessor from './refactorResultProcessor.js'
 import TemplateLoader from './templateLoaderService.js'
 import PromptContext from './promptContext.js'
-import { AutoContext } from './AutoContext.js'
+import AutoContext from './AutoContext.js'
 import { extractOperationsFromOutput } from './extractOperationsFromOutput.js'
 
 export default class PluginService {

--- a/src/services/promptContext.js
+++ b/src/services/promptContext.js
@@ -6,10 +6,13 @@ export default class PromptContext {
       files: [],
     }
     for (let n = 0; n < args.length; n++) {
-      context.files.push({
-        filename: args[n],
-        content: await FileService.load(args[n]),
-      })
+      const fileContent = await FileService.load(args[n]);
+      if (fileContent !== null) {
+        context.files.push({
+          filename: args[n],
+          content: fileContent,
+        })
+      }
     }
     return context
   }

--- a/test/AutoContext.test.js
+++ b/test/AutoContext.test.js
@@ -19,7 +19,7 @@ describe('AutoContext.call', () => {
     })
   })
 
-  describe('when the prompt mentions multiple paths', () => {
+  describe('when the prompt mentions multiple relative paths', () => {
     let prompt = 'add a new method to the class in src/services/AutoContext.js - also, do the same for the class in src/services/AnotherClass.js'
 
     it('returns an array of paths mentioned in the prompt', () => {
@@ -27,6 +27,18 @@ describe('AutoContext.call', () => {
       assert.deepStrictEqual([
         'src/services/AutoContext.js',
         'src/services/AnotherClass.js',
+    ], result)
+    })
+  })
+
+  describe('when the prompt mentions multiple absolute paths', () => {
+    let prompt = 'add a new method to the class in /src/services/AutoContext.js - also, do the same for the class in /src/services/AnotherClass.js'
+
+    it('returns an array of paths mentioned in the prompt', () => {
+      const result = AutoContext.call(prompt)
+      assert.deepStrictEqual([
+        '/src/services/AutoContext.js',
+        '/src/services/AnotherClass.js',
     ], result)
     })
   })

--- a/test/AutoContext.test.js
+++ b/test/AutoContext.test.js
@@ -1,0 +1,33 @@
+import assert from 'assert';
+import AutoContext from '../src/services/AutoContext.js';
+
+
+describe('AutoContext.call', () => {
+  let prompt = 'test prompt'
+
+  it('returns empty array if there are no paths mentioned in the prompt', () => {
+    const result = AutoContext.call(prompt)
+    assert.deepStrictEqual([], result)
+  })
+
+  describe('when the prompt mentions a path', () => {
+    let prompt = 'add a new method to the class in src/services/AutoContext.js'
+
+    it('returns an array of paths mentioned in the prompt', () => {
+      const result = AutoContext.call(prompt)
+      assert.deepStrictEqual(['src/services/AutoContext.js'], result)
+    })
+  })
+
+  describe('when the prompt mentions multiple paths', () => {
+    let prompt = 'add a new method to the class in src/services/AutoContext.js - also, do the same for the class in src/services/AnotherClass.js'
+
+    it('returns an array of paths mentioned in the prompt', () => {
+      const result = AutoContext.call(prompt)
+      assert.deepStrictEqual([
+        'src/services/AutoContext.js',
+        'src/services/AnotherClass.js',
+    ], result)
+    })
+  })
+})

--- a/test/PluginService_call.test.js
+++ b/test/PluginService_call.test.js
@@ -65,6 +65,19 @@ describe('PluginService', () => {
 
         assert(autoContextStub.calledWith(prompt))
       })
+
+      describe('when AutoContext is disabled', () => {
+        beforeEach(() => {
+          const args = ['node', 'index.js', '-m', 'gpt3', '-p', prompt, '--disable-auto-context']
+          CliState.init(args)
+        })
+
+        it('should not pass the paths from AutoContext.call into PromptContext.call', async () => {
+          await PluginService.call(prompt)
+  
+          assert(buildContextStub.calledWith([]))
+        })
+      })
     })
 
     it('should pass RefactorResultProcessor.call the operations', async () => {

--- a/test/PluginService_call.test.js
+++ b/test/PluginService_call.test.js
@@ -22,19 +22,14 @@ describe('PluginService', () => {
     beforeEach(() => {
       loadTemplateStub = sinon.stub(TemplateLoader, 'loadTemplate')
       buildContextStub = sinon.stub(PromptContext, 'call')
+      executeModeStub = sinon.stub(PluginService, 'executeMode')
     });
 
     afterEach(() => {
       if (loadTemplateStub) loadTemplateStub.restore()
       if (buildContextStub) buildContextStub.restore()
-    });
-
-    beforeEach(() => {    
-      executeModeStub = sinon.stub(PluginService, 'executeMode')
-    });
-  
-    afterEach(() => {
       if (executeModeStub) executeModeStub.restore()
+      sinon.restore()
     });
 
     it('should use refactor.txt as default template', async () => {
@@ -64,7 +59,7 @@ describe('PluginService', () => {
       loadTemplateStub.resolves('Test content');
       buildContextStub.resolves({ files: [] });
       executeModeStub.resolves('{ "operations": [] }');
-      CliState.getTemplatePath = sinon.stub().returns('');
+      sinon.stub(CliState, 'getExecuteFlag').returns('')
       
       await PluginService.call('Test input');
       

--- a/test/PluginService_call.test.js
+++ b/test/PluginService_call.test.js
@@ -45,16 +45,25 @@ describe('PluginService', () => {
 
     describe('when AutoContext.call() returns some paths', () => {
       let autoContextPaths = ['test/path1', 'test/path2']
+      let autoContextStub
+      const prompt = "Test prompt"
       
       beforeEach(() => {
         executeModeStub.resolves('{ "operations": [] }')
-        sinon.stub(AutoContext, 'call').returns(autoContextPaths)
+        autoContextStub = sinon.stub(AutoContext, 'call')
+        autoContextStub.returns(autoContextPaths)
       })
 
       it('should pass the paths from AutoContext.call into PromptContext.call', async () => {
-        await PluginService.call('Test input')
+        await PluginService.call(prompt)
 
         assert(buildContextStub.calledWith(autoContextPaths))
+      })
+
+      it('passes the prompt to AutoContext.call', async () => {
+        await PluginService.call(prompt)
+
+        assert(autoContextStub.calledWith(prompt))
       })
     })
 

--- a/test/PluginService_call.test.js
+++ b/test/PluginService_call.test.js
@@ -1,13 +1,11 @@
 import assert from 'assert';
 import sinon from 'sinon';
 import PluginService from '../src/services/pluginService.js';
-import OpenAiGptService from '../src/services/OpenAiGptService.js';
 import CliState from '../src/cliState.js';
 import RefactorResultProcessor from '../src/services/refactorResultProcessor.js';
 import TemplateLoader from '../src/services/templateLoaderService.js';
 import PromptContext from '../src/services/promptContext.js';
-import TemplateLoaderService from '../src/services/templateLoaderService.js'
-import { AutoContext } from '../src/services/AutoContext.js';
+import AutoContext from '../src/services/AutoContext.js';
 
 describe('PluginService', () => {
 

--- a/test/PluginService_call.test.js
+++ b/test/PluginService_call.test.js
@@ -7,6 +7,7 @@ import RefactorResultProcessor from '../src/services/refactorResultProcessor.js'
 import TemplateLoader from '../src/services/templateLoaderService.js';
 import PromptContext from '../src/services/promptContext.js';
 import TemplateLoaderService from '../src/services/templateLoaderService.js'
+import { AutoContext } from '../src/services/AutoContext.js';
 
 describe('PluginService', () => {
 
@@ -41,6 +42,21 @@ describe('PluginService', () => {
 
       assert(loadTemplateStub.calledWith('Test input', { files: [] }, sinon.match(/refactor$/)));
     });
+
+    describe('when AutoContext.call() returns some paths', () => {
+      let autoContextPaths = ['test/path1', 'test/path2']
+      
+      beforeEach(() => {
+        executeModeStub.resolves('{ "operations": [] }')
+        sinon.stub(AutoContext, 'call').returns(autoContextPaths)
+      })
+
+      it('should pass the paths from AutoContext.call into PromptContext.call', async () => {
+        await PluginService.call('Test input')
+
+        assert(buildContextStub.calledWith(autoContextPaths))
+      })
+    })
 
     it('should pass RefactorResultProcessor.call the operations', async () => {
       loadTemplateStub.resolves('Test content');

--- a/test/PluginService_call.test.js
+++ b/test/PluginService_call.test.js
@@ -1,0 +1,75 @@
+import assert from 'assert';
+import sinon from 'sinon';
+import PluginService from '../src/services/pluginService.js';
+import OpenAiGptService from '../src/services/OpenAiGptService.js';
+import CliState from '../src/cliState.js';
+import RefactorResultProcessor from '../src/services/refactorResultProcessor.js';
+import TemplateLoader from '../src/services/templateLoaderService.js';
+import PromptContext from '../src/services/promptContext.js';
+import TemplateLoaderService from '../src/services/templateLoaderService.js'
+
+describe('PluginService', () => {
+
+  beforeEach(() => {
+    CliState.init([], '')
+  })
+
+  describe('call method', () => {
+    let executeModeStub
+    let loadTemplateStub
+    let buildContextStub
+    
+    beforeEach(() => {
+      loadTemplateStub = sinon.stub(TemplateLoader, 'loadTemplate')
+      buildContextStub = sinon.stub(PromptContext, 'call')
+    });
+
+    afterEach(() => {
+      if (loadTemplateStub) loadTemplateStub.restore()
+      if (buildContextStub) buildContextStub.restore()
+    });
+
+    beforeEach(() => {    
+      executeModeStub = sinon.stub(PluginService, 'executeMode')
+    });
+  
+    afterEach(() => {
+      if (executeModeStub) executeModeStub.restore()
+    });
+
+    it('should use refactor.txt as default template', async () => {
+      loadTemplateStub.resolves('Test content');
+      buildContextStub.resolves({ files: [] });
+      executeModeStub.resolves('{ "operations": [] }');
+
+      await PluginService.call('Test input');
+
+      assert(loadTemplateStub.calledWith('Test input', { files: [] }, sinon.match(/refactor$/)));
+    });
+
+    it('should pass RefactorResultProcessor.call the operations', async () => {
+      loadTemplateStub.resolves('Test content');
+      buildContextStub.resolves({ files: [] });
+      executeModeStub.resolves('{ "operations": [{ "thing": 1 }] }');
+      const refactorResultProcessorStub = sinon.stub(RefactorResultProcessor, 'call').resolves();
+
+      await PluginService.call('Test input');
+
+      assert(refactorResultProcessorStub.calledWith({ operations: [{ thing: 1 }] }))
+
+      refactorResultProcessorStub.restore();
+    });
+
+    it('should call loadTemplate with default templatePath when CliState.getTemplatePath() is empty or undefined', async () => {
+      loadTemplateStub.resolves('Test content');
+      buildContextStub.resolves({ files: [] });
+      executeModeStub.resolves('{ "operations": [] }');
+      CliState.getTemplatePath = sinon.stub().returns('');
+      
+      await PluginService.call('Test input');
+      
+      assert(loadTemplateStub.calledWith(sinon.match.any, { files: [] }, "refactor"))
+    });
+  });
+
+});

--- a/test/PluginService_executeMode.test.js
+++ b/test/PluginService_executeMode.test.js
@@ -21,6 +21,7 @@ describe('PluginService', () => {
   
     afterEach(() => {
       if (OpenAiGptServiceStub) OpenAiGptServiceStub.restore()
+      sinon.restore()
     });
 
     it('should call OpenAiGptService when mode is gpt3', async () => {

--- a/test/PluginService_executeMode.test.js
+++ b/test/PluginService_executeMode.test.js
@@ -4,8 +4,6 @@ import PluginService from '../src/services/pluginService.js';
 import OpenAiGptService from '../src/services/OpenAiGptService.js';
 import CliState from '../src/cliState.js';
 import RefactorResultProcessor from '../src/services/refactorResultProcessor.js';
-import TemplateLoader from '../src/services/templateLoaderService.js';
-import PromptContext from '../src/services/promptContext.js';
 import TemplateLoaderService from '../src/services/templateLoaderService.js'
 
 describe('PluginService', () => {
@@ -88,86 +86,5 @@ describe('PluginService', () => {
 
     });
   });
-
-  describe('call method', () => {
-    let executeModeStub
-    let loadTemplateStub
-    let buildContextStub
-    
-    beforeEach(() => {
-      loadTemplateStub = sinon.stub(TemplateLoader, 'loadTemplate')
-      buildContextStub = sinon.stub(PromptContext, 'call')
-    });
-
-    afterEach(() => {
-      if (loadTemplateStub) loadTemplateStub.restore()
-      if (buildContextStub) buildContextStub.restore()
-    });
-
-    beforeEach(() => {    
-      executeModeStub = sinon.stub(PluginService, 'executeMode')
-    });
-  
-    afterEach(() => {
-      if (executeModeStub) executeModeStub.restore()
-    });
-
-    it('should use refactor.txt as default template', async () => {
-      loadTemplateStub.resolves('Test content');
-      buildContextStub.resolves({ files: [] });
-      executeModeStub.resolves('{ "operations": [] }');
-
-      await PluginService.call('Test input');
-
-      assert(loadTemplateStub.calledWith('Test input', { files: [] }, sinon.match(/refactor$/)));
-    });
-
-    it('should pass RefactorResultProcessor.call the operations', async () => {
-      loadTemplateStub.resolves('Test content');
-      buildContextStub.resolves({ files: [] });
-      executeModeStub.resolves('{ "operations": [{ "thing": 1 }] }');
-      const refactorResultProcessorStub = sinon.stub(RefactorResultProcessor, 'call').resolves();
-
-      await PluginService.call('Test input');
-
-      assert(refactorResultProcessorStub.calledWith({ operations: [{ thing: 1 }] }))
-
-      refactorResultProcessorStub.restore();
-    });
-
-    it('should call loadTemplate with default templatePath when CliState.getTemplatePath() is empty or undefined', async () => {
-      loadTemplateStub.resolves('Test content');
-      buildContextStub.resolves({ files: [] });
-      executeModeStub.resolves('{ "operations": [] }');
-      CliState.getTemplatePath = sinon.stub().returns('');
-      
-      await PluginService.call('Test input');
-      
-      assert(loadTemplateStub.calledWith(sinon.match.any, { files: [] }, "refactor"))
-    });
-  });
-
-  describe('shouldRefactor method', () => {
-    it('returns true if templatePath is refactor', () => {
-      const result = PluginService.shouldRefactor('refactor')
-      assert.strictEqual(result, true)
-    })
-
-    it('returns true if templatePath is not provided', () => {
-      const result = PluginService.shouldRefactor(undefined)
-      assert.strictEqual(result, true)
-    })
-
-    it('returns false if templatePath is not refactor', () => {
-      const result = PluginService.shouldRefactor('not-refactor')
-      assert.strictEqual(result, false)
-    })
-
-    it('returns true if CliState.getExecuteFlag() is truthy', () => {
-      sinon.stub(CliState, 'getExecuteFlag').returns(true)
-      const result = PluginService.shouldRefactor('not-refactor')
-      assert.strictEqual(result, true)
-    })
-  })
 
 });

--- a/test/PluginService_shouldRefactor.test.js
+++ b/test/PluginService_shouldRefactor.test.js
@@ -1,0 +1,40 @@
+import assert from 'assert';
+import sinon from 'sinon';
+import PluginService from '../src/services/pluginService.js';
+import OpenAiGptService from '../src/services/OpenAiGptService.js';
+import CliState from '../src/cliState.js';
+import RefactorResultProcessor from '../src/services/refactorResultProcessor.js';
+import TemplateLoader from '../src/services/templateLoaderService.js';
+import PromptContext from '../src/services/promptContext.js';
+import TemplateLoaderService from '../src/services/templateLoaderService.js'
+
+describe('PluginService', () => {
+
+  beforeEach(() => {
+    CliState.init([], '')
+  })
+
+  describe('shouldRefactor method', () => {
+    it('returns true if templatePath is refactor', () => {
+      const result = PluginService.shouldRefactor('refactor')
+      assert.strictEqual(result, true)
+    })
+
+    it('returns true if templatePath is not provided', () => {
+      const result = PluginService.shouldRefactor(undefined)
+      assert.strictEqual(result, true)
+    })
+
+    it('returns false if templatePath is not refactor', () => {
+      const result = PluginService.shouldRefactor('not-refactor')
+      assert.strictEqual(result, false)
+    })
+
+    it('returns true if CliState.getExecuteFlag() is truthy', () => {
+      sinon.stub(CliState, 'getExecuteFlag').returns(true)
+      const result = PluginService.shouldRefactor('not-refactor')
+      assert.strictEqual(result, true)
+    })
+  })
+
+});

--- a/test/fileService.test.js
+++ b/test/fileService.test.js
@@ -36,10 +36,10 @@ describe('FileService', () => {
       assert.strictEqual(fileContents, data);
     });
 
-    it('should return an empty string if the file does not exist', async () => {
+    it('should return null if the file does not exist', async () => {
       const filePath = 'tmp/nonexistent-file.txt';
       const fileContents = await FileService.load(filePath);
-      assert.strictEqual(fileContents, '');
+      assert.strictEqual(fileContents, null);
     });
   });
 

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -18,6 +18,7 @@ describe('Main', () => {
   after(function () {
     fsExistsMock.restore()
     readFileSyncMock.restore()
+    sinon.restore()
   })
 
 

--- a/test/promptContext.test.js
+++ b/test/promptContext.test.js
@@ -29,6 +29,20 @@ describe('PromptContext', () => {
         ]
       });
     });
+
+    it('should not add files with null content to context', async () => {
+      fileServiceStub.onCall(0).resolves('File content');
+      fileServiceStub.onCall(1).resolves(null);
+
+      const args = ['file1.js', 'file2.js'];
+      const context = await PromptContext.call(args);
+
+      assert.deepEqual(context, {
+        files: [
+          { filename: 'file1.js', content: 'File content' }
+        ]
+      });
+    });
   });
 
 });


### PR DESCRIPTION
This PR adds an "auto-context" feature. The feature is on by default, but the user can use `-dac` or `--disable-auto-context` to turn it off. The feature looks at the user's input and automatically includes any files references by the user as additional context to be sent with the request to the model.

For example, if the prompt is "Add comments for the class defined in /src/services/Something.js" then `Something.js` will be included with the request as if the user had specified the path to `Something.js` as an argument.

The commits below were produced with promptr - the prompts are included in the commit message:
- https://github.com/ferrislucas/promptr/pull/41/commits/2c9bcc0f51da892e6532654f77b3b7c749ccfa4c
- https://github.com/ferrislucas/promptr/pull/41/commits/692ab032b67a6d3f76d31eb6b705d259f8d97122
- https://github.com/ferrislucas/promptr/pull/41/commits/e1f4e0d4211a99967e1ad31fc66214c9897a6e39
- https://github.com/ferrislucas/promptr/pull/41/commits/f0d14e27e65e833b12ef99d16c6dcca247412ae5
