### PR TITLE
Fix edge case: duplicate files included in context 

### DIFF
--- a/src/services/AutoContext.js
+++ b/src/services/AutoContext.js
@@ -11,7 +11,9 @@ export default class AutoContext {
     let match;
 
     while ((match = regex.exec(prompt)) !== null) {
-      filePaths.push(match[1]);
+      if (!filePaths.includes(match[1])) {
+        filePaths.push(match[1]);
+      }
     }
 
     return filePaths;

--- a/src/services/PromptrService.js
+++ b/src/services/PromptrService.js
@@ -22,7 +22,7 @@ export default class PromptrService {
     }
     if (CliState.getModel() != "execute") {
       let args = CliState.args      
-      if (!CliState.disableAutoContext()) args = args.concat(AutoContext.call(userInput))      
+      if (!CliState.disableAutoContext()) args = args.concat(AutoContext.call(userInput))
       let context = await PromptContext.call(args)
       const __filename = fileURLToPath(import.meta.url)
 

--- a/test/AutoContext.test.js
+++ b/test/AutoContext.test.js
@@ -42,4 +42,15 @@ describe('AutoContext.call', () => {
     ], result)
     })
   })
+
+  describe('when the prompt mentions duplicate paths', () => {
+    let prompt = 'modify the class in /src/services/AutoContext.js and also make changes in /src/services/AutoContext.js'
+
+    it('returns an array of unique paths mentioned in the prompt', () => {
+      const result = AutoContext.call(prompt)
+      assert.deepStrictEqual([
+        '/src/services/AutoContext.js'
+    ], result)
+    })
+  })
 })


### PR DESCRIPTION
This PR fixes an issue where files are included in the context more than once if the file is mentioned more than once in the prompt.