### PR TITLE
Enable use of custom basePath

### DIFF
--- a/src/services/OpenAiGptService.js
+++ b/src/services/OpenAiGptService.js
@@ -11,7 +11,8 @@ export default class OpenAiGptService {
     if (model == "gpt4") model = "gpt-4o";
 
     const configuration = new Configuration({
-      apiKey: process.env.OPENAI_API_KEY
+      apiKey: process.env.OPENAI_API_KEY,
+      basePath: process.env.OPENAI_API_BASE || "https://api.openai.com/v1"
     })
     const verbose = CliState.verbose()
     const openai = new OpenAIApi(configuration)


### PR DESCRIPTION
Closes https://github.com/ferrislucas/promptr/issues/60

Leverages that basePath option to allow for using custom proxy URLs (useful if your company for instance doesn't allow access to api.openai.com directly). Uses the standard ENV names used by other OpenAI client libraries.