### PR TITLE
Fix auto context to exclude file paths inside liquid comment tags

### DIFF
--- a/src/services/AutoContext.js
+++ b/src/services/AutoContext.js
@@ -11,11 +11,26 @@ export default class AutoContext {
     let match;
 
     while ((match = regex.exec(prompt)) !== null) {
-      if (!filePaths.includes(match[1])) {
+      if (!filePaths.includes(match[1]) && !this.isInsideLiquidComment(prompt, match.index)) {
         filePaths.push(match[1]);
       }
     }
 
     return filePaths;
+  }
+
+  /**
+   * Checks if a file path is inside a liquid comment tag.
+   *
+   * @param {string} prompt - The input prompt containing file paths.
+   * @param {number} index - The index of the file path in the prompt.
+   * @returns {boolean} True if the file path is inside a liquid comment tag, false otherwise.
+   */
+  static isInsideLiquidComment(prompt, index) {
+    const before = prompt.slice(0, index);
+    const after = prompt.slice(index);
+    const openTag = before.lastIndexOf('{% comment %}');
+    const closeTag = before.lastIndexOf('{% endcomment %}');
+    return openTag > closeTag && after.includes('{% endcomment %}');
   }
 }

--- a/test/AutoContext.test.js
+++ b/test/AutoContext.test.js
@@ -1,3 +1,4 @@
+import { describe, it } from 'mocha'
 import assert from 'assert';
 import AutoContext from '../src/services/AutoContext.js';
 

--- a/test/AutoContext.test.js
+++ b/test/AutoContext.test.js
@@ -51,6 +51,21 @@ describe('AutoContext.call', () => {
       assert.deepStrictEqual([
         '/src/services/AutoContext.js'
     ], result)
+  })
+
+  describe('when the prompt mentions paths inside liquid comment tags', () => {
+    let prompt = `
+      Instructions here
+
+      {% comment %}
+      // this file shouldn't be included in the prompt sent to the LLM
+      See file /abc/test.txt
+      {% endcomment %}
+    `
+
+    it('excludes paths inside liquid comment tags', () => {
+      const result = AutoContext.call(prompt)
+      assert.deepStrictEqual([], result)
     })
   })
 })

--- a/test/ExtractOperationsService.test.js
+++ b/test/ExtractOperationsService.test.js
@@ -1,3 +1,4 @@
+import { describe, it } from 'mocha'
 import assert from 'assert'
 import { ExtractOperationsService } from '../src/services/ExtractOperationsService.js'
 

--- a/test/FileService.test.js
+++ b/test/FileService.test.js
@@ -1,3 +1,4 @@
+import { describe, it } from 'mocha'
 import { FileService } from '../src/services/FileService.js';
 import fs from 'fs';
 import assert from 'assert';

--- a/test/Main.test.js
+++ b/test/Main.test.js
@@ -1,3 +1,4 @@
+import { describe, it } from 'mocha'
 import assert from 'assert'
 import Main from '../src/Main.js'
 import PromptrService from '../src/services/PromptrService.js'

--- a/test/OpenAiGptService.test.js
+++ b/test/OpenAiGptService.test.js
@@ -1,3 +1,4 @@
+import { describe, it } from 'mocha'
 import assert from 'assert';
 import sinon from 'sinon';
 import OpenAiGptService from '../src/services/OpenAiGptService.js';

--- a/test/PromptContext.test.js
+++ b/test/PromptContext.test.js
@@ -1,3 +1,4 @@
+import { describe, it } from 'mocha'
 import assert from 'assert';
 import sinon from 'sinon';
 import PromptContext from '../src/services/PromptContext.js';

--- a/test/PromptrService_call.test.js
+++ b/test/PromptrService_call.test.js
@@ -1,3 +1,4 @@
+import { describe, it } from 'mocha'
 import assert from 'assert';
 import sinon from 'sinon';
 import PromptrService from '../src/services/PromptrService.js';

--- a/test/PromptrService_executeMode.test.js
+++ b/test/PromptrService_executeMode.test.js
@@ -1,3 +1,4 @@
+import { describe, it } from 'mocha'
 import assert from 'assert';
 import sinon from 'sinon';
 import PromptrService from '../src/services/PromptrService.js';

--- a/test/PromptrService_shouldRefactor.test.js
+++ b/test/PromptrService_shouldRefactor.test.js
@@ -1,3 +1,4 @@
+import { describe, it } from 'mocha'
 import assert from 'assert';
 import sinon from 'sinon';
 import PromptrService from '../src/services/PromptrService.js';

--- a/test/cliState.test.js
+++ b/test/cliState.test.js
@@ -1,3 +1,4 @@
+import { describe, it } from 'mocha'
 import assert from 'assert';
 import CliState from '../src/CliState.js';
 

--- a/test/refactorResultProcessor.test.js
+++ b/test/refactorResultProcessor.test.js
@@ -1,3 +1,4 @@
+import { describe, it } from 'mocha'
 import fs from 'fs';
 import path from 'path';
 import assert from 'assert';


### PR DESCRIPTION
Related to #59

Exclude file paths inside liquid comment tags from being sent to the LLM.

* Update `src/services/AutoContext.js` to filter out file paths inside liquid comment tags when extracting file paths from the prompt.
* Add a helper function `isInsideLiquidComment` to check if a file path is inside a liquid comment tag.
* Add test cases in `test/AutoContext.test.js` to verify that file paths inside liquid comment tags are excluded.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ferrislucas/promptr/issues/59?shareId=eca25456-9a1c-4f40-a7fd-c4f037c49fbd).